### PR TITLE
Stopped chat list from appearing in console

### DIFF
--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -75,7 +75,7 @@ export default class ChatList {
     this.$chat_rooms_container = $(document.createElement('div'));
     this.$chat_rooms_container.addClass('chat-rooms-container');
     this.chat_rooms = [];
-    console.log(this.rooms)
+    //console.log(this.rooms)
     this.rooms.forEach((element) => {
       let profile = {
         user: this.user,


### PR DESCRIPTION
Currently the chat list is published in console.

<img width="1852" height="103" alt="image" src="https://github.com/user-attachments/assets/3cb44ddf-b2c7-40dd-82c5-316f7840de7c" />

Identified and commented a console.log.