### PR TITLE
feat: show human-readable contact name in chat list using WhatsApp Profiles title

### DIFF
--- a/whatsapp_chat/api/contact_sync.py
+++ b/whatsapp_chat/api/contact_sync.py
@@ -1,0 +1,240 @@
+"""Resolve WhatsApp numbers to ERPNext Contacts and keep names in step.
+
+WhatsApp reports a number as 918884477288 — country code, no plus. ERPNext
+Contacts on this site store bare ten-digit locals (8884477288), and the
+Contact Phone rows carry whatever the importer wrote, spaces and all. The
+last ten digits are the only thing both sides reliably agree on.
+"""
+
+import re
+
+import frappe
+
+MOBILE_DIGITS = 10
+
+
+def normalize_number(number):
+    """Last ten digits of a phone number, or None if it is not a number."""
+    if not number:
+        return None
+
+    digits = re.sub(r"\D", "", str(number))
+    if len(digits) < MOBILE_DIGITS:
+        return None
+
+    return digits[-MOBILE_DIGITS:]
+
+
+def _contact_full_name(contact):
+    row = frappe.db.get_value(
+        "Contact", contact, ["first_name", "last_name"], as_dict=True
+    )
+    if not row:
+        return None
+
+    return " ".join(part for part in (row.first_name, row.last_name) if part).strip() or None
+
+
+def find_contact(number):
+    """Resolve a WhatsApp number to one ERPNext Contact.
+
+    Returns (contact, full_name), or (None, None) when there is no safe
+    answer.
+
+    The Contact table here is heavily duplicated: the same person exists as
+    "Arun Prakash", "Arun Prakash-1" and "Arun Prakash-2", and each carries
+    two Contact Phone rows — one flagged primary mobile, one primary phone.
+    Duplicates that agree on the name are harmless, so they collapse on the
+    name and the oldest Contact wins, which keeps the answer stable as more
+    duplicates arrive.
+
+    A number that maps to two genuinely *different* people resolves to
+    nothing. Showing the wrong customer's name against a live chat is worse
+    than showing the number, and one number on this site (919400510794)
+    already does exactly that.
+    """
+    digits = normalize_number(number)
+    if not digits:
+        return None, None
+
+    rows = frappe.db.sql(
+        """
+        SELECT
+            c.name,
+            c.creation,
+            TRIM(CONCAT(COALESCE(c.first_name, ''), ' ', COALESCE(c.last_name, ''))) AS full_name,
+            MAX(cp.is_primary_mobile_no) AS is_mobile
+        FROM `tabContact Phone` cp
+        JOIN `tabContact` c ON c.name = cp.parent
+        WHERE RIGHT(REGEXP_REPLACE(cp.phone, '[^0-9]', ''), 10) = %(digits)s
+        GROUP BY c.name, c.creation, full_name
+        """,
+        {"digits": digits},
+        as_dict=True,
+    )
+
+    named = [row for row in rows if row.full_name]
+    if not named:
+        return None, None
+
+    if len({row.full_name for row in named}) > 1:
+        return None, None
+
+    named.sort(key=lambda row: (0 if row.is_mobile else 1, row.creation))
+
+    return named[0].name, named[0].full_name
+
+
+def resolve_display_name(mobile_no, fallback=None):
+    """Best available name for a number, and the Contact it came from.
+
+    ERPNext Contact first, as agreed — it is the business record. Meta's own
+    profile name is the fallback, which is all we have for 141 of the 146
+    rooms on this site, and is still far better than a bare number.
+    """
+    contact, full_name = find_contact(mobile_no)
+    if full_name:
+        return contact, full_name
+
+    profile_name = frappe.db.get_value(
+        "WhatsApp Profiles", {"number": mobile_no}, "profile_name"
+    )
+
+    return None, profile_name or fallback or None
+
+
+def _propagate_profile_name(mobile_no, full_name):
+    """Push the resolved name onto this number's incoming messages.
+
+    Only incoming: profile_name means "the name the sender goes by", so
+    stamping a customer's name onto our own outgoing messages would be
+    wrong.
+
+    Written straight to the database rather than through the document, so
+    WhatsAppMessage.update_profile_name() does not fire and overwrite the
+    WhatsApp Profiles record with a name Meta never sent.
+    """
+    return frappe.db.sql(
+        """
+        UPDATE `tabWhatsApp Message`
+        SET profile_name = %(full_name)s
+        WHERE `from` = %(mobile_no)s
+          AND COALESCE(profile_name, '') != %(full_name)s
+        """,
+        {"full_name": full_name, "mobile_no": mobile_no},
+    )
+
+
+def apply_to_room(room, doc=None):
+    """Give a WhatsApp Contact its best name and link its ERPNext Contact.
+
+    An existing link wins over a fresh lookup: it is either our own earlier
+    match or a correction the owner made by hand, and both should stick.
+    Clearing the Contact field forces a re-match on the next message.
+    """
+    contact = room.get("contact")
+    full_name = None
+
+    if contact and frappe.db.exists("Contact", contact):
+        full_name = _contact_full_name(contact)
+    else:
+        contact, full_name = resolve_display_name(
+            room.mobile_no, fallback=doc.profile_name if doc else None
+        )
+
+    values = {}
+    if contact and contact != room.get("contact"):
+        values["contact"] = contact
+    if full_name and full_name != room.contact_name:
+        values["contact_name"] = full_name
+
+    if values:
+        frappe.db.set_value("WhatsApp Contact", room.name, values, update_modified=False)
+        room.update(values)
+
+    if full_name:
+        _propagate_profile_name(room.mobile_no, full_name)
+
+    return full_name
+
+
+@frappe.whitelist()
+def sync_contact(mobile_no):
+    """Re-resolve one room on demand. Returns the name that was applied."""
+    frappe.only_for("System Manager")
+
+    name = frappe.db.get_value("WhatsApp Contact", {"mobile_no": mobile_no})
+    if not name:
+        return None
+
+    full_name = apply_to_room(frappe.get_doc("WhatsApp Contact", name))
+    frappe.db.commit()
+
+    return full_name
+
+
+def refresh_unlinked_rooms():
+    """Daily: re-check rooms that have no ERPNext Contact yet.
+
+    A number often reaches WhatsApp before anyone creates the Contact for
+    it. Without this the room would keep Meta's name forever, because
+    apply_to_room only runs when a message arrives.
+    """
+    rooms = frappe.get_all(
+        "WhatsApp Contact",
+        filters={"contact": ["in", ["", None]]},
+        pluck="name",
+    )
+
+    for name in rooms:
+        try:
+            apply_to_room(frappe.get_doc("WhatsApp Contact", name))
+        except Exception:
+            frappe.log_error(
+                f"Could not refresh WhatsApp Contact {name}", "WhatsApp Contact Sync"
+            )
+
+    frappe.db.commit()
+
+    return len(rooms)
+
+
+@frappe.whitelist()
+def backfill(mark_read=True):
+    """One-off repair of rooms and messages created before this shipped.
+
+    Names are resolved for every room. Old incoming messages are marked read
+    locally *only* — no receipts go to Meta. Blue-ticking months-old chats
+    that nobody actually answered would tell customers something untrue, and
+    Meta rejects receipts outside its window anyway.
+    """
+    frappe.only_for("System Manager")
+
+    from whatsapp_chat.api.message import READ_STATUS
+
+    named = 0
+    for name in frappe.get_all("WhatsApp Contact", pluck="name"):
+        room = frappe.get_doc("WhatsApp Contact", name)
+        before = room.contact_name
+        if apply_to_room(room) and room.contact_name != before:
+            named += 1
+
+    marked = 0
+    if mark_read:
+        pending = frappe.db.sql(
+            "SELECT name FROM `tabWhatsApp Message` WHERE type = 'Incoming' AND COALESCE(status, '') = ''",
+            pluck="name",
+        )
+        if pending:
+            frappe.db.set_value(
+                "WhatsApp Message",
+                {"name": ("in", pending)},
+                "status",
+                READ_STATUS,
+                update_modified=False,
+            )
+            marked = len(pending)
+
+    frappe.db.commit()
+
+    return {"rooms_renamed": named, "messages_marked_read": marked}

--- a/whatsapp_chat/api/contacts.py
+++ b/whatsapp_chat/api/contacts.py
@@ -18,6 +18,75 @@ def create(contact_name, mobile_no, email):
 
 
 @frappe.whitelist()
+def unread_count(email=None):
+    """Number of chats with something still unread — the navbar badge.
+
+    Derived from message status, not from WhatsApp Contact.is_read. is_read
+    is a cached summary maintained by hooks; the messages are the fact. The
+    badge used to keep a running +1/-1 tally in the browser instead, and
+    several paths mark a room read without telling it (chat_list's
+    mark_message_read when a message lands on an open chat, and both
+    chat_space calls), so the number drifted and never recovered short of a
+    page reload.
+
+    Counts chats, not messages: one customer sending twenty lines is one
+    conversation waiting for an answer.
+    """
+    from whatsapp_chat.api.message import READ_STATUS
+
+    return frappe.db.sql(
+        """
+        SELECT COUNT(*)
+        FROM `tabWhatsApp Contact` wc
+        WHERE IFNULL(wc.email, '') IN (%(email)s, '')
+          AND EXISTS (
+              SELECT 1
+              FROM `tabWhatsApp Message` m
+              WHERE m.`from` = wc.mobile_no
+                AND m.type = 'Incoming'
+                AND COALESCE(m.status, '') != %(read_status)s
+          )
+        """,
+        {"email": email or frappe.session.user, "read_status": READ_STATUS},
+    )[0][0]
+
+
+def reconcile_read_flags():
+    """Bring WhatsApp Contact.is_read back in line with the messages.
+
+    is_read is a cache, so anything that moved message status without going
+    through the hooks — a backfill, a manual edit, an older build — leaves
+    rooms claiming to be unread with nothing unread in them. The chat list
+    then highlights empty rooms and the badge counts them.
+    """
+    from whatsapp_chat.api.message import READ_STATUS
+
+    unread_exists = """
+        EXISTS (
+            SELECT 1 FROM `tabWhatsApp Message` m
+            WHERE m.`from` = wc.mobile_no
+              AND m.type = 'Incoming'
+              AND COALESCE(m.status, '') != %(read_status)s
+        )
+    """
+
+    repaired = 0
+    for flag, condition in ((1, "NOT " + unread_exists), (0, unread_exists)):
+        repaired += frappe.db.sql(
+            f"""
+            UPDATE `tabWhatsApp Contact` wc
+            SET wc.is_read = {flag}
+            WHERE wc.is_read != {flag} AND {condition}
+            """,
+            {"read_status": READ_STATUS},
+        )
+
+    frappe.db.commit()
+
+    return repaired
+
+
+@frappe.whitelist()
 def get(email):
     """Get all contacts assigned to email, enriched with WhatsApp Profiles display name."""
     contacts = frappe.db.get_all(

--- a/whatsapp_chat/api/contacts.py
+++ b/whatsapp_chat/api/contacts.py
@@ -2,6 +2,7 @@ import frappe
 
 
 
+
 @frappe.whitelist()
 def create(contact_name, mobile_no, email):
     """Create contact."""
@@ -14,12 +15,27 @@ def create(contact_name, mobile_no, email):
     return "email"
 
 
+
+
 @frappe.whitelist()
 def get(email):
-    """Get all contacts assigned to email."""
-    return frappe.db.get_all(
+    """Get all contacts assigned to email, enriched with WhatsApp Profiles display name."""
+    contacts = frappe.db.get_all(
         "WhatsApp Contact",
-        filters={"email": ['in', [email, '']]},
-        fields=["*"])
-    return data
+        filters={"email": ["in", [email, ""]]},
+        fields=["*"],
+    )
 
+    # Enrich each contact with a display_name from WhatsApp Profiles.
+    # WhatsApp Profiles stores a human-readable title (e.g. "Ravi - 917842272227")
+    # that is set automatically from the sender's profile name on each incoming message.
+    # Falling back to contact_name (which is the raw phone number) keeps backward compatibility.
+    for contact in contacts:
+        profile_title = frappe.db.get_value(
+            "WhatsApp Profiles",
+            {"number": contact.get("mobile_no")},
+            "title",
+        )
+        contact["display_name"] = profile_title or contact.get("contact_name") or contact.get("mobile_no")
+
+    return contacts

--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -1,8 +1,6 @@
 import frappe
 import mimetypes
 
-
-
 @frappe.whitelist()
 def get_all(room: str, user_no: str):
     """Get all the messages of a particular room
@@ -17,21 +15,25 @@ def get_all(room: str, user_no: str):
             when `to` <> '' then `to`
             else
             'Administrator'
-        end as sender_user_no,
+            end as sender_user_no,
         case
             when COALESCE(content_type, 'text') = 'text' then COALESCE(message, '')
             else COALESCE(attach, message, '')
-        end as content,
+            end as content,
         case
             when COALESCE(content_type, 'text') <> 'text' then message
             else NULL
-        end as caption,
-        COALESCE(content_type, 'text') as content_type
+            end as caption,
+        COALESCE(content_type, 'text') as content_type,
+        COALESCE(status, 'sent') as status,
+        case
+            when `to` <> '' then 'Outgoing'
+            else 'Incoming'
+            end as direction
         from `tabWhatsApp Message` where (`to` = %(user_no)s or `from` = %(user_no)s)
         AND COALESCE(message_type, '') <> 'Template'
         order by creation asc
-    """, {"user_no": user_no}, as_dict=True)
-
+        """, {"user_no": user_no}, as_dict=True)
 
 @frappe.whitelist()
 def mark_as_read(room):
@@ -44,9 +46,8 @@ def mark_as_read(room):
         # Send read receipts to WhatsApp if enabled
         send_whatsapp_read_receipts(room)
     except Exception:
-        pass  # Ignore concurrent update errors
+        pass # Ignore concurrent update errors
     return "ok"
-
 
 def send_whatsapp_read_receipts(room):
     """Send read receipts to WhatsApp for unread incoming messages."""
@@ -92,8 +93,6 @@ def send_whatsapp_read_receipts(room):
     except Exception as e:
         frappe.log_error(f"send_whatsapp_read_receipts error: {str(e)}", "WhatsApp Chat Read Receipt")
 
-
-
 @frappe.whitelist()
 def send(content, user, room, user_no, attachment=None):
     content_type = "text"
@@ -126,13 +125,11 @@ def send(content, user, room, user_no, attachment=None):
 
     return "ok"
 
-
 def last_message(doc, method):
     if doc.type == 'Outgoing':
         mobile_no = doc.to
     else:
         mobile_no = doc.get("from")
-
 
     contact_name = frappe.db.get_value("WhatsApp Contact", filters={"mobile_no": mobile_no})
     if contact_name:

--- a/whatsapp_chat/api/message.py
+++ b/whatsapp_chat/api/message.py
@@ -1,6 +1,11 @@
 import frappe
 import mimetypes
 
+from whatsapp_chat.api import contact_sync
+
+# The status frappe_whatsapp writes once Meta accepts a read receipt.
+READ_STATUS = "marked as read"
+
 @frappe.whitelist()
 def get_all(room: str, user_no: str):
     """Get all the messages of a particular room
@@ -37,61 +42,108 @@ def get_all(room: str, user_no: str):
 
 @frappe.whitelist()
 def mark_as_read(room):
-    """Mark messages as read in local DB and optionally send read receipts to WhatsApp."""
+    """Mark a room read — called by the chat UI when a room is opened."""
     try:
-        # Update local contact status
-        frappe.db.set_value("WhatsApp Contact", room, "is_read", 1, update_modified=False)
+        mark_conversation_read(room)
         frappe.db.commit()
-
-        # Send read receipts to WhatsApp if enabled
-        send_whatsapp_read_receipts(room)
     except Exception:
-        pass # Ignore concurrent update errors
+        frappe.log_error(frappe.get_traceback(), "WhatsApp Chat Mark As Read")
     return "ok"
 
-def send_whatsapp_read_receipts(room):
-    """Send read receipts to WhatsApp for unread incoming messages."""
-    try:
-        # Get the contact's mobile number
-        contact = frappe.get_doc("WhatsApp Contact", room)
-        if not contact.mobile_no:
-            return
 
-        # Find unread incoming messages for this contact
-        unread_messages = frappe.get_all(
-            "WhatsApp Message",
-            filters={
-                "from": contact.mobile_no,
-                "type": "Incoming",
-                "status": ["not in", ["marked as read"]]
-            },
-            fields=["name", "whatsapp_account"],
-            order_by="creation desc",
-            limit=10
+def mark_conversation_read(room, send_receipt=True):
+    """Clear a conversation's unread state, locally and at Meta.
+
+    Called when a room is opened *and* on every outgoing message, so a reply
+    from the chat UI, the REST API or Claude Desktop all settle the
+    conversation identically. Previously only the UI path existed, which is
+    why a chat answered from Claude Desktop stayed unread until someone
+    opened it by hand.
+
+    Note the direction of travel. Meta reports statuses only for messages we
+    *sent* (sent -> delivered -> read), and that already works. "Read" on an
+    incoming message is something we push *to* Meta; it never arrives on the
+    webhook. There is nothing to fetch.
+
+    `room` accepts a name or a loaded document.
+    """
+    if isinstance(room, str):
+        room = frappe.get_doc("WhatsApp Contact", room)
+
+    if not room.mobile_no:
+        return 0
+
+    if not room.is_read:
+        frappe.db.set_value(
+            "WhatsApp Contact", room.name, "is_read", 1, update_modified=False
         )
+        room.is_read = 1
 
-        if not unread_messages:
-            return
+    # COALESCE, not a `!=` filter: 477 incoming messages on this site have a
+    # NULL status, and `status != 'marked as read'` evaluates to NULL for
+    # every one of them in SQL — so the old filter matched nothing at all.
+    pending = frappe.db.sql(
+        """
+        SELECT name, message_id, whatsapp_account
+        FROM `tabWhatsApp Message`
+        WHERE `from` = %(mobile_no)s
+          AND type = 'Incoming'
+          AND COALESCE(status, '') != %(status)s
+        ORDER BY creation DESC
+        """,
+        {"mobile_no": room.mobile_no, "status": READ_STATUS},
+        as_dict=True,
+    )
 
-        # Check if auto read receipt is enabled for the account
-        for msg in unread_messages:
-            if not msg.whatsapp_account:
-                continue
+    if not pending:
+        return 0
 
-            allow_auto_read = frappe.db.get_value(
-                "WhatsApp Account",
-                msg.whatsapp_account,
-                "allow_auto_read_receipt"
-            )
+    # One receipt, for the newest message. Meta settles the whole
+    # conversation from it, so a chat with 40 unread messages costs one API
+    # call rather than 40.
+    if send_receipt:
+        send_read_receipt(pending[0])
 
-            if allow_auto_read:
-                try:
-                    msg_doc = frappe.get_doc("WhatsApp Message", msg.name)
-                    msg_doc.send_read_receipt()
-                except Exception as e:
-                    frappe.log_error(f"Failed to send read receipt for {msg.name}: {str(e)}", "WhatsApp Chat Read Receipt")
-    except Exception as e:
-        frappe.log_error(f"send_whatsapp_read_receipts error: {str(e)}", "WhatsApp Chat Read Receipt")
+    frappe.db.set_value(
+        "WhatsApp Message",
+        {"name": ("in", [msg.name for msg in pending])},
+        "status",
+        READ_STATUS,
+        update_modified=False,
+    )
+
+    return len(pending)
+
+
+def send_read_receipt(message):
+    """Push a read receipt to Meta for one message, if the account allows it.
+
+    Silent no-op when `allow_auto_read_receipt` is off on the WhatsApp
+    Account — that switch is the business's decision about whether senders
+    see blue ticks, and it is respected here rather than worked around.
+    """
+    if not message.get("message_id") or not message.get("whatsapp_account"):
+        return False
+
+    if not frappe.db.get_value(
+        "WhatsApp Account", message.whatsapp_account, "allow_auto_read_receipt"
+    ):
+        return False
+
+    try:
+        frappe.get_doc("WhatsApp Message", message.name).send_read_receipt()
+        return True
+    except Exception:
+        frappe.log_error(
+            f"Read receipt failed for {message.name}\n\n{frappe.get_traceback()}",
+            "WhatsApp Chat Read Receipt",
+        )
+        return False
+
+
+def send_whatsapp_read_receipts(room):
+    """Kept for callers outside this module; use mark_conversation_read()."""
+    return mark_conversation_read(room)
 
 @frappe.whitelist()
 def send(content, user, room, user_no, attachment=None):
@@ -126,16 +178,27 @@ def send(content, user, room, user_no, attachment=None):
     return "ok"
 
 def last_message(doc, method):
-    if doc.type == 'Outgoing':
-        mobile_no = doc.to
-    else:
-        mobile_no = doc.get("from")
+    """after_insert on WhatsApp Message — keep the chat list in step.
+
+    Three jobs in order: refresh the room, give it its best name, then
+    settle the read state. The name is resolved before the realtime push so
+    the chat list shows the customer's name rather than their number.
+    """
+    is_outgoing = doc.type == "Outgoing"
+    mobile_no = doc.to if is_outgoing else doc.get("from")
+
+    if not mobile_no:
+        return "ok"
 
     contact_name = frappe.db.get_value("WhatsApp Contact", filters={"mobile_no": mobile_no})
     if contact_name:
         chat_doc = frappe.get_doc("WhatsApp Contact", contact_name)
         chat_doc.last_message = doc.message
-        chat_doc.is_read = 0
+        # An outgoing message IS the reply, so the conversation has been
+        # dealt with and must not flip back to unread. Setting is_read = 0
+        # unconditionally here is what made a Claude Desktop reply leave the
+        # chat looking unanswered until someone opened it by hand.
+        chat_doc.is_read = 1 if is_outgoing else 0
         chat_doc.save(ignore_permissions=True)
     else:
         chat_doc = frappe.get_doc({
@@ -143,9 +206,18 @@ def last_message(doc, method):
             "mobile_no": mobile_no,
             "last_message": doc.message,
             "contact_name": mobile_no,
-            "is_read": 0
+            "is_read": 1 if is_outgoing else 0
         })
         chat_doc.save(ignore_permissions=True)
+
+    try:
+        contact_sync.apply_to_room(chat_doc, doc)
+    except Exception:
+        # A name is a nicety; never let it stop a message being recorded.
+        frappe.log_error(frappe.get_traceback(), "WhatsApp Contact Sync")
+
+    if is_outgoing:
+        mark_conversation_read(chat_doc)
 
     if chat_doc.email and doc.type != 'Outgoing':
         message_data = {

--- a/whatsapp_chat/hooks.py
+++ b/whatsapp_chat/hooks.py
@@ -154,7 +154,12 @@ scheduler_events = {
         # Contact for it. Without this, a room keeps Meta's profile name for
         # good, because names are otherwise only resolved when a message
         # arrives.
-        "whatsapp_chat.api.contact_sync.refresh_unlinked_rooms"
+        "whatsapp_chat.api.contact_sync.refresh_unlinked_rooms",
+        # WhatsApp Contact.is_read is a cache over the message statuses.
+        # Anything that moves a status outside the hooks leaves rooms
+        # claiming to be unread with nothing unread in them, which the chat
+        # list highlights and the badge counts.
+        "whatsapp_chat.api.contacts.reconcile_read_flags",
     ]
 }
 

--- a/whatsapp_chat/hooks.py
+++ b/whatsapp_chat/hooks.py
@@ -148,6 +148,16 @@ doc_events = {
 # Scheduled Tasks
 # ---------------
 
+scheduler_events = {
+    "daily": [
+        # A number usually reaches WhatsApp before anyone creates the ERPNext
+        # Contact for it. Without this, a room keeps Meta's profile name for
+        # good, because names are otherwise only resolved when a message
+        # arrives.
+        "whatsapp_chat.api.contact_sync.refresh_unlinked_rooms"
+    ]
+}
+
 # scheduler_events = {
 #	"all": [
 #		"whatsapp_chat.tasks.all"

--- a/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
+++ b/whatsapp_chat/public/css/whatsapp_chat.bundle.scss
@@ -446,3 +446,34 @@ $height: 582px;
     border: 1px solid var(--red-avatar-color);
   }
 }
+
+// ===== iWEX Enhancements =====
+
+// Feature 5: Unread message highlight in chat list
+.chat-room--unread {
+  background-color: rgba(37, 211, 102, 0.08);
+  border-left: 3px solid #25d366;
+
+  .chat-name {
+    font-weight: 600;
+  }
+}
+
+// Feature 2: Chat image hover state (lightbox cursor)
+.chat-image {
+  cursor: zoom-in !important;
+  border-radius: 8px;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+// Feature 4: Message tick/status icons
+.message-time {
+  svg {
+    vertical-align: middle;
+    margin-left: 2px;
+  }
+}

--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -85,7 +85,7 @@ export default class ChatList {
         is_admin: this.is_admin,
         room: element.name,
         is_read: element.is_read,
-        room_name: element.contact_name,
+        room_name: element.display_name || element.contact_name,
         room_type: element.type,
         opposite_person_email: element.mobile_no,
       };

--- a/whatsapp_chat/public/js/components/chat_list.js
+++ b/whatsapp_chat/public/js/components/chat_list.js
@@ -1,7 +1,12 @@
 import ChatRoom from './chat_room';
 import ChatAddRoom from './chat_add_room';
 import ChatUserSettings from './chat_user_settings';
-import { get_rooms, mark_message_read, set_notification_count } from './chat_utils';
+import {
+  get_rooms,
+  mark_message_read,
+  set_notification_count,
+  refresh_notification_count,
+} from './chat_utils';
 
 export default class ChatList {
   constructor(opts) {
@@ -63,6 +68,9 @@ export default class ChatList {
       this.rooms = res;
       this.setup_rooms();
       this.render_messages();
+      // Seed the badge from the server once the list exists, rather than
+      // counting rooms as they are constructed.
+      refresh_notification_count();
     } catch (error) {
       frappe.msgprint({
         title: __('Error'),
@@ -215,6 +223,10 @@ export default class ChatList {
         me.move_room_to_top(chat_room_item);
       } else if ($('.chat-space').is(':visible')) {
         mark_message_read(res.room);
+        // Keep the in-memory profile honest about what the server was just
+        // told. Left at 0, a later click would decrement the badge for a
+        // room that had already been counted as read.
+        chat_room_item[1].profile.is_read = 1;
       } else {
         // Chat widget is closed - update counter only if room was previously read
         if (chat_room_item[1].profile.is_read === 1) {

--- a/whatsapp_chat/public/js/components/chat_room.js
+++ b/whatsapp_chat/public/js/components/chat_room.js
@@ -1,122 +1,129 @@
 import ChatSpace from './chat_space';
 import {
-  get_date_from_now,
-  mark_message_read,
-  get_time,
-  get_avatar_html,
-  set_notification_count,
+	get_date_from_now,
+	mark_message_read,
+	get_time,
+	get_avatar_html,
+	set_notification_count,
 } from './chat_utils';
 
 export default class ChatRoom {
-  constructor(opts) {
-    this.$wrapper = opts.$wrapper;
-    this.$chat_rooms_container = opts.$chat_rooms_container;
-    this.chat_list = opts.chat_list;
-    this.profile = opts.element;
-    this.setup();
-    if (!this.profile.is_read) {
-      set_notification_count('increment');
-    }
-  }
+	constructor(opts) {
+		this.$wrapper = opts.$wrapper;
+		this.$chat_rooms_container = opts.$chat_rooms_container;
+		this.chat_list = opts.chat_list;
+		this.profile = opts.element;
+		this.setup();
+		if (!this.profile.is_read) {
+			set_notification_count('increment');
+		}
+	}
 
-  setup() {
-    this.$chat_room = $(document.createElement('div'));
-    this.$chat_room.addClass('chat-room');
+	setup() {
+		this.$chat_room = $(document.createElement('div'));
+		this.$chat_room.addClass('chat-room');
 
-    this.avatar_html = get_avatar_html(
-      this.profile.room_type,
-      this.profile.opposite_person_email,
-      this.profile.room_name
-    );
+		// Add unread highlight class if message is unread
+		if (!this.profile.is_read) {
+			this.$chat_room.addClass('chat-room--unread');
+		}
 
-    let last_message = this.sanitize_last_message(this.profile.last_message);
+		this.avatar_html = get_avatar_html(
+			this.profile.room_type,
+			this.profile.opposite_person_email,
+			this.profile.room_name
+		);
 
-    const info_html = `
+		let last_message = this.sanitize_last_message(this.profile.last_message);
+
+		const info_html = `
 			<div class='chat-profile-info'>
 				<div class='chat-name'>
-					${__(this.profile.room_name)} 
-					<div class='chat-latest' 
+					${__(this.profile.room_name)}
+					<div class='chat-latest'
 						style='display: ${this.profile.is_read ? 'none' : 'inline-block'}'
 					></div>
 				</div>
 				<div style='color: ${
-          this.profile.is_read ? 'var(--text-muted)' : 'var(--text-color)'
-        }' class='last-message'>${__(last_message)}</div>
+					this.profile.is_read ? 'var(--text-muted)' : 'var(--text-color)'
+				}' class='last-message'>${__(last_message)}</div>
 			</div>
 		`;
-    const date_html = `
+		const date_html = `
 			<div class='chat-date'>
 				${__(get_date_from_now(this.profile.last_date, 'room'))}
 			</div>
 		`;
-    let inner_html = '';
+		let inner_html = '';
 
-    inner_html += this.avatar_html + info_html + date_html;
+		inner_html += this.avatar_html + info_html + date_html;
 
-    this.$chat_room.html(inner_html);
-  }
+		this.$chat_room.html(inner_html);
+	}
 
-  sanitize_last_message(message) {
-    let sanitize_last_message = $('<div>').text(message).html();
-    if (sanitize_last_message) {
-      if (sanitize_last_message.length > 20) {
-        sanitize_last_message = sanitize_last_message.substring(0, 20) + '...';
-      }
-    }
-    return sanitize_last_message;
-  }
+	sanitize_last_message(message) {
+		let sanitize_last_message = $('<div>').text(message).html();
+		if (sanitize_last_message) {
+			if (sanitize_last_message.length > 20) {
+				sanitize_last_message = sanitize_last_message.substring(0, 20) + '...';
+			}
+		}
+		return sanitize_last_message;
+	}
 
-  set_as_read() {
-    this.profile.is_read = 1;
-    this.$chat_room.find('.last-message').css('color', 'var(--text-muted)');
-    this.$chat_room.find('.chat-latest').hide();
-    set_notification_count('decrement');
-  }
+	set_as_read() {
+		this.profile.is_read = 1;
+		this.$chat_room.find('.last-message').css('color', 'var(--text-muted)');
+		this.$chat_room.find('.chat-latest').hide();
+		this.$chat_room.removeClass('chat-room--unread');
+		set_notification_count('decrement');
+	}
 
-  set_last_message(message, date) {
-    const sanitized_message = this.sanitize_last_message(message);
-    this.$chat_room.find('.last-message').html(__(sanitized_message));
-    this.$chat_room.find('.chat-date').text(__(get_time(date)));
-  }
+	set_last_message(message, date) {
+		const sanitized_message = this.sanitize_last_message(message);
+		this.$chat_room.find('.last-message').html(__(sanitized_message));
+		this.$chat_room.find('.chat-date').text(__(get_time(date)));
+	}
 
-  set_as_unread() {
-    if (this.profile.is_read) {
-      set_notification_count('increment');
-    }
-    this.profile.is_read = 0;
-    this.$chat_room.find('.last-message').css('color', 'var(--text-color)');
-    this.$chat_room.find('.chat-latest').show();
-  }
+	set_as_unread() {
+		if (this.profile.is_read) {
+			set_notification_count('increment');
+		}
+		this.profile.is_read = 0;
+		this.$chat_room.find('.last-message').css('color', 'var(--text-color)');
+		this.$chat_room.find('.chat-latest').show();
+		this.$chat_room.addClass('chat-room--unread');
+	}
 
-  render(mode) {
-    if (mode == 'append') {
-      this.$chat_rooms_container.append(this.$chat_room);
-    } else {
-      this.$chat_rooms_container.prepend(this.$chat_room);
-    }
+	render(mode) {
+		if (mode == 'append') {
+			this.$chat_rooms_container.append(this.$chat_room);
+		} else {
+			this.$chat_rooms_container.prepend(this.$chat_room);
+		}
 
-    this.setup_events();
-  }
+		this.setup_events();
+	}
 
-  move_to_top() {
-    $(this.$chat_room).prependTo(this.$chat_rooms_container);
-  }
+	move_to_top() {
+		$(this.$chat_room).prependTo(this.$chat_rooms_container);
+	}
 
-  setup_events() {
-    this.$chat_room.on('click', () => {
-      // Always create new ChatSpace to fetch latest messages
-      if (typeof this.chat_space !== 'undefined') {
-        this.chat_space.destroy_socket_events();
-      }
-      this.chat_space = new ChatSpace({
-        $wrapper: this.$wrapper,
-        chat_list: this.chat_list,
-        profile: this.profile,
-      });
-      if (this.profile.is_read === 0) {
-        mark_message_read(this.profile.room);
-        this.set_as_read();
-      }
-    });
-  }
+	setup_events() {
+		this.$chat_room.on('click', () => {
+			// Always create new ChatSpace to fetch latest messages
+			if (typeof this.chat_space !== 'undefined') {
+				this.chat_space.destroy_socket_events();
+			}
+			this.chat_space = new ChatSpace({
+				$wrapper: this.$wrapper,
+				chat_list: this.chat_list,
+				profile: this.profile,
+			});
+			if (this.profile.is_read === 0) {
+				mark_message_read(this.profile.room);
+				this.set_as_read();
+			}
+		});
+	}
 }

--- a/whatsapp_chat/public/js/components/chat_room.js
+++ b/whatsapp_chat/public/js/components/chat_room.js
@@ -14,9 +14,10 @@ export default class ChatRoom {
 		this.chat_list = opts.chat_list;
 		this.profile = opts.element;
 		this.setup();
-		if (!this.profile.is_read) {
-			set_notification_count('increment');
-		}
+		// The badge is no longer seeded by counting rooms as they are built:
+		// ChatList asks the server once the list is up. Incrementing here
+		// double-counted whenever a room object was rebuilt for a chat that
+		// was already on the badge.
 	}
 
 	setup() {
@@ -72,11 +73,16 @@ export default class ChatRoom {
 	}
 
 	set_as_read() {
+		// Guarded exactly as set_as_unread() is. Without this, reading a room
+		// that was already read still decremented the badge, so the count
+		// drifted below the truth.
+		if (!this.profile.is_read) {
+			set_notification_count('decrement');
+		}
 		this.profile.is_read = 1;
 		this.$chat_room.find('.last-message').css('color', 'var(--text-muted)');
 		this.$chat_room.find('.chat-latest').hide();
 		this.$chat_room.removeClass('chat-room--unread');
-		set_notification_count('decrement');
 	}
 
 	set_last_message(message, date) {

--- a/whatsapp_chat/public/js/components/chat_space.js
+++ b/whatsapp_chat/public/js/components/chat_space.js
@@ -1,151 +1,195 @@
 import {
-  get_time,
-  scroll_to_bottom,
-  get_messages,
-  get_date_from_now,
-  is_date_change,
-  send_message,
-  set_typing,
-  is_image,
-  get_avatar_html,
-  mark_message_read,
+	get_time,
+	scroll_to_bottom,
+	get_messages,
+	get_date_from_now,
+	is_date_change,
+	send_message,
+	set_typing,
+	is_image,
+	get_avatar_html,
+	mark_message_read,
 } from './chat_utils';
 
 export default class ChatSpace {
-  constructor(opts) {
-    this.chat_list = opts.chat_list;
-    this.$wrapper = opts.$wrapper;
-    this.profile = opts.profile;
-    this.file = null;
-    this.setup();
-  }
+	constructor(opts) {
+		this.chat_list = opts.chat_list;
+		this.$wrapper = opts.$wrapper;
+		this.profile = opts.profile;
+		this.file = null;
+		this.setup();
+	}
 
-  setup() {
-    this.$chat_space = $(document.createElement('div'));
-    this.typing = false;
-    this.$chat_space.addClass('chat-space');
-    this.setup_header();
-    this.fetch_and_setup_messages();
-    this.setup_socketio();
-  }
+	setup() {
+		this.$chat_space = $(document.createElement('div'));
+		this.typing = false;
+		this.$chat_space.addClass('chat-space');
+		this.setup_header();
+		this.fetch_and_setup_messages();
+		this.setup_socketio();
+		this.setup_lightbox();
+	}
 
-  setup_header() {
-    this.avatar_html = get_avatar_html(
-      this.profile.room_type,
-      this.profile.opposite_person_email,
-      this.profile.room_name
-    );
-    const header_html = `
+	setup_lightbox() {
+		// Create a single lightbox overlay for image viewing
+		if ($('#wa-lightbox').length) return;
+		const $lb = $(`
+			<div id="wa-lightbox" style="
+				display:none;position:fixed;top:0;left:0;width:100%;height:100%;
+				background:rgba(0,0,0,0.88);z-index:99999;
+				align-items:center;justify-content:center;flex-direction:column;">
+				<div style="position:absolute;top:16px;right:16px;display:flex;gap:12px;">
+					<a id="wa-lb-download" download style="
+						color:#fff;background:rgba(255,255,255,0.2);
+						border:1px solid rgba(255,255,255,0.4);border-radius:6px;
+						padding:6px 14px;text-decoration:none;font-size:13px;cursor:pointer;">
+						&#8659; Download
+					</a>
+					<button id="wa-lb-close" style="
+						color:#fff;background:rgba(255,255,255,0.2);
+						border:1px solid rgba(255,255,255,0.4);border-radius:6px;
+						padding:6px 14px;font-size:13px;cursor:pointer;">&#10005; Close</button>
+				</div>
+				<img id="wa-lb-img" src="" style="max-width:90vw;max-height:85vh;border-radius:8px;box-shadow:0 8px 40px rgba(0,0,0,0.6);">
+			</div>
+		`);
+		$('body').append($lb);
+
+		$('#wa-lb-close').on('click', () => {
+			$('#wa-lightbox').hide().css('display','none');
+		});
+		$('#wa-lightbox').on('click', function(e) {
+			if (e.target === this) $(this).hide().css('display','none');
+		});
+		$(document).on('keydown.wa-lb', (e) => {
+			if (e.key === 'Escape') $('#wa-lightbox').hide().css('display','none');
+		});
+	}
+
+	open_lightbox(src) {
+		$('#wa-lb-img').attr('src', src);
+		$('#wa-lb-download').attr('href', src).attr('download', src.split('/').pop() || 'image');
+		$('#wa-lightbox').css('display','flex');
+	}
+
+	setup_header() {
+		this.avatar_html = get_avatar_html(
+			this.profile.room_type,
+			this.profile.opposite_person_email,
+			this.profile.room_name
+		);
+		const header_html = `
 			<div class='chat-header'>
 				${
-          this.profile.is_admin === true
-            ? `<span class='chat-back-button' title='${__('Go Back')}' >
-								${frappe.utils.icon('left')}
+					this.profile.is_admin === true
+						? `<span class='chat-back-button' title='${__('Go Back')}' >
+							${frappe.utils.icon('left')}
 							</span>`
-            : ``
-        }
+						: ``
+				}
 				${this.avatar_html}
 				<div class='chat-profile-info'>
 					<div class='chat-profile-name'>
-					${__(this.profile.room_name)}
-					<div class='online-circle'></div>
+						${__(this.profile.room_name)}
+						<div class='online-circle'></div>
 					</div>
 					<div class='chat-profile-status'>${__('Typing...')}</div>
 				</div>
 			</div>
 		`;
-    this.$chat_space.append(header_html);
-  }
+		this.$chat_space.append(header_html);
+	}
 
-  async fetch_and_setup_messages() {
-    try {
-      const res = await get_messages(
-        this.profile.room,
-        this.profile.user_email
-      );
-      this.setup_messages(res);
-      this.setup_actions();
-      this.render();
+	async fetch_and_setup_messages() {
+		try {
+			const res = await get_messages(
+				this.profile.room,
+				this.profile.user_email
+			);
+			this.setup_messages(res);
+			this.setup_actions();
+			this.render();
 
-      // Mark messages as read when viewing the chat
-      // This will also send read receipts to WhatsApp if enabled in settings
-      mark_message_read(this.profile.room);
-    } catch (error) {
-      frappe.msgprint({
-        title: __('Error'),
-        message: __('Something went wrong. Please refresh and try again.'),
-      });
-    }
-  }
+			// Mark messages as read when viewing the chat
+			mark_message_read(this.profile.room);
+		} catch (error) {
+			frappe.msgprint({
+				title: __('Error'),
+				message: __('Something went wrong. Please refresh and try again.'),
+			});
+		}
+	}
 
-  setup_messages(messages_list) {
-    this.$chat_space_container = $(document.createElement('div'));
-    this.$chat_space_container.addClass('chat-space-container');
+	setup_messages(messages_list) {
+		this.$chat_space_container = $(document.createElement('div'));
+		this.$chat_space_container.addClass('chat-space-container');
 
-    this.make_messages_html(messages_list);
+		this.make_messages_html(messages_list);
 
-    this.$chat_space_container.html(this.message_html);
-    this.$chat_space.append(this.$chat_space_container);
-  }
+		this.$chat_space_container.html(this.message_html);
+		this.$chat_space.append(this.$chat_space_container);
+	}
 
-  make_messages_html(messages_list) {
-    this.prevMessage = {};
-    this.message_html = ``;
-    if (this.profile.message) {
-      messages_list.push(this.profile.message);
-      send_message(
-        this.profile.message.content,
-        this.profile.user,
-        this.profile.room,
-        this.profile.user_email
-      );
-    }
-    messages_list.forEach((element) => {
-      const date_line_html = this.make_date_line_html(element.creation);
-      this.message_html += date_line_html;
+	make_messages_html(messages_list) {
+		this.prevMessage = {};
+		this.message_html = ``;
+		if (this.profile.message) {
+			messages_list.push(this.profile.message);
+			send_message(
+				this.profile.message.content,
+				this.profile.user,
+				this.profile.room,
+				this.profile.user_email
+			);
+		}
+		messages_list.forEach((element) => {
+			const date_line_html = this.make_date_line_html(element.creation);
+			this.message_html += date_line_html;
 
-      let message_type = 'sender';
+			let message_type = 'sender';
 
-      if (element.sender_user_no === this.profile.user_email) {
-        message_type = 'recipient';
-      } else if (this.profile.room_type === 'Guest') {
-        if (this.profile.is_admin === true && element.sender !== 'Guest') {
-          message_type = 'recipient';
-        }
-      }
-      this.message_html += this.make_message(
-        element.content,
-        get_time(element.creation),
-        message_type,
-        element.sender,
-        element.caption
-      ).prop('outerHTML');
+			if (element.sender_user_no === this.profile.user_email) {
+				message_type = 'recipient';
+			} else if (this.profile.room_type === 'Guest') {
+				if (this.profile.is_admin === true && element.sender !== 'Guest') {
+					message_type = 'recipient';
+				}
+			}
+			this.message_html += this.make_message(
+				element.content,
+				get_time(element.creation),
+				message_type,
+				element.sender,
+				element.caption,
+				element.status,
+				element.direction
+			).prop('outerHTML');
 
-      this.prevMessage = element;
-    });
-  }
+			this.prevMessage = element;
+		});
+	}
 
-  make_date_line_html(dateObj) {
-    let result = `
+	make_date_line_html(dateObj) {
+		let result = `
 			<div class='date-line'>
 				<span>
 					${__(get_date_from_now(dateObj, 'space'))}
 				</span>
 			</div>
 		`;
-    if ($.isEmptyObject(this.prevMessage)) {
-      return result;
-    } else if (is_date_change(dateObj, this.prevMessage.creation)) {
-      return result;
-    } else {
-      return '';
-    }
-  }
+		if ($.isEmptyObject(this.prevMessage)) {
+			return result;
+		} else if (is_date_change(dateObj, this.prevMessage.creation)) {
+			return result;
+		} else {
+			return '';
+		}
+	}
 
-  setup_actions() {
-    this.$chat_actions = $(document.createElement('div'));
-    this.$chat_actions.addClass('chat-space-actions');
-    const chat_actions_html = `
+	setup_actions() {
+		this.$chat_actions = $(document.createElement('div'));
+		this.$chat_actions.addClass('chat-space-actions');
+		const chat_actions_html = `
 			<span class='open-attach-items'>
 				${frappe.utils.icon('attachment', 'lg')}
 			</span>
@@ -165,313 +209,351 @@ export default class ChatSpace {
 				</span>
 			</div>
 		`;
-    this.$chat_actions.html(chat_actions_html);
-    this.$chat_space.append(this.$chat_actions);
-  }
+		this.$chat_actions.html(chat_actions_html);
+		this.$chat_space.append(this.$chat_actions);
+	}
 
-  async handle_upload_file(file) {
-    const dataurl = await frappe.dom.file_to_base64(file.file_obj);
-    file.dataurl = dataurl;
-    file.name = file.file_obj.name;
-    return this.upload_file(file);
-  }
+	async handle_upload_file(file) {
+		const dataurl = await frappe.dom.file_to_base64(file.file_obj);
+		file.dataurl = dataurl;
+		file.name = file.file_obj.name;
+		return this.upload_file(file);
+	}
 
-  upload_file(file) {
-    const me = this;
-    return new Promise((resolve, reject) => {
-      let xhr = new XMLHttpRequest();
+	upload_file(file) {
+		const me = this;
+		return new Promise((resolve, reject) => {
+			let xhr = new XMLHttpRequest();
 
-      xhr.upload.addEventListener('load', () => {
-        resolve();
-      });
+			xhr.upload.addEventListener('load', () => {
+				resolve();
+			});
 
-      xhr.addEventListener('error', () => {
-        reject(frappe.throw(__('Internal Server Error')));
-      });
-      xhr.onreadystatechange = () => {
-        if (xhr.readyState == XMLHttpRequest.DONE) {
-          if (xhr.status === 200) {
-            let r = null;
-            let file_doc = null;
-            try {
-              r = JSON.parse(xhr.responseText);
-              if (r.message.doctype === 'File') {
-                file_doc = r.message;
-              }
-            } catch (e) {
-              r = xhr.responseText;
-            }
-            try {
-              if (file_doc === null) {
-                reject(frappe.throw(__('File upload failed!')));
-              }
-              me.handle_send_message(file_doc.file_url);
-            } catch (error) {
-              //pass
-            }
-          } else {
-            try {
-              const error = JSON.parse(xhr.responseText);
-              const messages = JSON.parse(error._server_messages);
-              const errorObj = JSON.parse(messages[0]);
-              reject(frappe.throw(__(errorObj.message)));
-            } catch (e) {
-              // pass
-            }
-          }
-        }
-      };
+			xhr.addEventListener('error', () => {
+				reject(frappe.throw(__('Internal Server Error')));
+			});
+			xhr.onreadystatechange = () => {
+				if (xhr.readyState == XMLHttpRequest.DONE) {
+					if (xhr.status === 200) {
+						let r = null;
+						let file_doc = null;
+						try {
+							r = JSON.parse(xhr.responseText);
+							if (r.message.doctype === 'File') {
+								file_doc = r.message;
+							}
+						} catch (e) {
+							r = xhr.responseText;
+						}
+						try {
+							if (file_doc === null) {
+								reject(frappe.throw(__('File upload failed!')));
+							}
+							me.handle_send_message(file_doc.file_url);
+						} catch (error) {
+							//pass
+						}
+					} else {
+						try {
+							const error = JSON.parse(xhr.responseText);
+							const messages = JSON.parse(error._server_messages);
+							const errorObj = JSON.parse(messages[0]);
+							reject(frappe.throw(__(errorObj.message)));
+						} catch (e) {
+							// pass
+						}
+					}
+				}
+			};
 
-      xhr.open('POST', '/api/method/upload_file', true);
-      xhr.setRequestHeader('Accept', 'application/json');
-      xhr.setRequestHeader('X-Frappe-CSRF-Token', frappe.csrf_token);
+			xhr.open('POST', '/api/method/upload_file', true);
+			xhr.setRequestHeader('Accept', 'application/json');
+			xhr.setRequestHeader('X-Frappe-CSRF-Token', frappe.csrf_token);
 
-      let form_data = new FormData();
+			let form_data = new FormData();
 
-      form_data.append('file', file.file_obj, file.name);
-      form_data.append('is_private', +false);
+			form_data.append('file', file.file_obj, file.name);
+			form_data.append('is_private', +false);
 
-      form_data.append('doctype', 'WhatsApp Contact');
-      form_data.append('docname', this.profile.room);
-      form_data.append('optimize', +true);
-      xhr.send(form_data);
-    });
-  }
+			form_data.append('doctype', 'WhatsApp Contact');
+			form_data.append('docname', this.profile.room);
+			form_data.append('optimize', +true);
+			xhr.send(form_data);
+		});
+	}
 
-  setup_events() {
-    const me = this;
+	setup_events() {
+		const me = this;
 
-    //Timeout function
-    me.typing_timeout = () => {
-      me.typing = false;
-    };
+		//Timeout function
+		me.typing_timeout = () => {
+			me.typing = false;
+		};
 
-    $('.chat-back-button').on('click', function () {
-      me.chat_list.render_messages();
-      me.chat_list.render();
-    });
+		$('.chat-back-button').on('click', function () {
+			me.chat_list.render_messages();
+			me.chat_list.render();
+		});
 
-    $('.open-attach-items').on('click', function () {
-      $('#chat-file-uploader').click();
-    });
+		$('.open-attach-items').on('click', function () {
+			$('#chat-file-uploader').click();
+		});
 
-    $('#chat-file-uploader').on('change', function () {
-      if (this.files.length > 0) {
-        me.file = {};
-        me.file.file_obj = this.files[0];
-        me.handle_upload_file(me.file);
-        me.file = null;
-      }
-    });
+		$('#chat-file-uploader').on('change', function () {
+			if (this.files.length > 0) {
+				me.file = {};
+				me.file.file_obj = this.files[0];
+				me.handle_upload_file(me.file);
+				me.file = null;
+			}
+		});
 
-    $('.message-send-button').on('click', function () {
-      me.handle_send_message();
-    });
+		$('.message-send-button').on('click', function () {
+			me.handle_send_message();
+		});
 
-    $('.type-message').keydown(function (e) {
-      if (e.which === 13) {
-        me.handle_send_message();
-      }
-    });
-  }
+		$('.type-message').keydown(function (e) {
+			if (e.which === 13) {
+				me.handle_send_message();
+			}
+		});
 
-  setup_socketio() {
-    const me = this;
-    // Track received message IDs to prevent duplicates
-    this.received_message_ids = new Set();
+		// Image lightbox events (delegated so they work for dynamically added images)
+		this.$chat_space_container.on('click', '.chat-image', function () {
+			const src = $(this).attr('src');
+			if (src) me.open_lightbox(src);
+		});
+	}
 
-    // Listen for room-specific messages
-    frappe.realtime.on(this.profile.room, function (res) {
-      me.handle_incoming_message(res);
-    });
+	setup_socketio() {
+		const me = this;
+		// Track received message IDs to prevent duplicates
+		this.received_message_ids = new Set();
 
-    // Also listen for latest_chat_updates and filter by room
-    frappe.realtime.on('latest_chat_updates', function (res) {
-      if (res.room === me.profile.room) {
-        me.handle_incoming_message(res);
-      }
-    });
-  }
+		// Listen for room-specific messages
+		frappe.realtime.on(this.profile.room, function (res) {
+			me.handle_incoming_message(res);
+		});
 
-  handle_incoming_message(res) {
-    // Create a unique ID for the message to prevent duplicates
-    const msg_id = res.name || `${res.content}-${res.creation}-${res.sender_user_no}`;
+		// Also listen for latest_chat_updates and filter by room
+		frappe.realtime.on('latest_chat_updates', function (res) {
+			if (res.room === me.profile.room) {
+				me.handle_incoming_message(res);
+			}
+		});
+	}
 
-    // Skip if we've already processed this message
-    if (this.received_message_ids.has(msg_id)) {
-      return;
-    }
-    this.received_message_ids.add(msg_id);
+	handle_incoming_message(res) {
+		// Create a unique ID for the message to prevent duplicates
+		const msg_id = res.name || `${res.content}-${res.creation}-${res.sender_user_no}`;
 
-    // Display the message
-    this.receive_message(res, get_time(res.creation));
+		// Skip if we've already processed this message
+		if (this.received_message_ids.has(msg_id)) {
+			return;
+		}
+		this.received_message_ids.add(msg_id);
 
-    // Mark as read since chat is open and user is viewing it
-    mark_message_read(this.profile.room);
-  }
+		// Display the message
+		this.receive_message(res, get_time(res.creation));
 
-  destroy_socket_events() {
-    frappe.realtime.off(this.profile.room);
-    frappe.realtime.off('latest_chat_updates');
-  }
+		// Mark as read since chat is open and user is viewing it
+		mark_message_read(this.profile.room);
+	}
 
-  get_typing_changes(res) {
-    if (res.user != this.profile.user_email) {
-      if (
-        (this.profile.is_admin === true && res.is_guest === 'true') ||
-        this.profile.is_admin === false ||
-        this.profile.room_type === 'Group' ||
-        this.profile.room_type === 'Direct'
-      ) {
-        if (res.is_typing === 'false') {
-          $('.chat-profile-status').css('visibility', 'hidden');
-        } else {
-          $('.chat-profile-status').css('visibility', 'visible');
-          const timeout = setTimeout(() => {
-            $('.chat-profile-status').css('visibility', 'hidden');
-          }, 3000);
-        }
-      }
-    }
-  }
+	destroy_socket_events() {
+		frappe.realtime.off(this.profile.room);
+		frappe.realtime.off('latest_chat_updates');
+	}
 
-  make_message(content, time, type, name, caption) {
-    const message_class =
-      type === 'recipient' ? 'recipient-message' : 'sender-message';
-    const $recipient_element = $(document.createElement('div')).addClass(
-      message_class
-    );
-    const $message_element = $(document.createElement('div')).addClass(
-      'message-bubble'
-    );
+	get_typing_changes(res) {
+		if (res.user != this.profile.user_email) {
+			if (
+				(this.profile.is_admin === true && res.is_guest === 'true') ||
+				this.profile.is_admin === false ||
+				this.profile.room_type === 'Group' ||
+				this.profile.room_type === 'Direct'
+			) {
+				if (res.is_typing === 'false') {
+					$('.chat-profile-status').css('visibility', 'hidden');
+				} else {
+					$('.chat-profile-status').css('visibility', 'visible');
+					const timeout = setTimeout(() => {
+						$('.chat-profile-status').css('visibility', 'hidden');
+					}, 3000);
+				}
+			}
+		}
+	}
 
-    const $name_element = $(document.createElement('div'))
-      .addClass('message-name')
-      .text(name);
+	/**
+	 * Returns SVG tick icon(s) for message status.
+	 * - sent: single grey tick
+	 * - delivered: double grey tick
+	 * - read: double blue tick
+	 */
+	get_status_tick(status, direction) {
+		// Only show for outgoing messages
+		if (direction !== 'Outgoing') return '';
+		const grey = '#aaa';
+		const blue = '#4fc3f7';
+		const tick = (color) => `<svg width="11" height="8" viewBox="0 0 11 8" fill="none" xmlns="http://www.w3.org/2000/svg" style="display:inline-block;vertical-align:middle;">
+			<path d="M1 4L4 7L10 1" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+		</svg>`;
+		const double_tick = (color) => `<span style="display:inline-flex;align-items:center;gap:-4px;">
+			<svg width="14" height="8" viewBox="0 0 14 8" fill="none" xmlns="http://www.w3.org/2000/svg" style="vertical-align:middle;">
+				<path d="M1 4L4 7L10 1" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				<path d="M4 4L7 7L13 1" stroke="${color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+			</svg>
+		</span>`;
+		const st = (status || 'sent').toLowerCase();
+		if (st === 'read') return double_tick(blue);
+		if (st === 'delivered') return double_tick(grey);
+		return tick(grey); // sent, failed, or unknown
+	}
 
-    const n = content.lastIndexOf('/');
-    const file_name = content.substring(n + 1) || '';
-    let $sanitized_content;
+	make_message(content, time, type, name, caption, status, direction) {
+		const message_class =
+			type === 'recipient' ? 'recipient-message' : 'sender-message';
+		const $recipient_element = $(document.createElement('div')).addClass(
+			message_class
+		);
+		const $message_element = $(document.createElement('div')).addClass(
+			'message-bubble'
+		);
 
-    if (content.startsWith('/files/') && file_name !== '') {
-      let $url;
-      if (is_image(file_name)) {
-        $url = $(document.createElement('img'));
-        $url.attr({ src: content }).addClass('img-responsive chat-image');
-        $message_element.css({ padding: '0px', background: 'inherit' });
-        $name_element.css({
-          color: 'var(--text-muted)',
-          'padding-bottom': 'var(--padding-xs)',
-        });
-      } else {
-        $url = $(document.createElement('a'));
-        $url.attr({ href: content, target: '_blank' }).text(__(file_name));
+		const $name_element = $(document.createElement('div'))
+			.addClass('message-name')
+			.text(name);
 
-        if (type === 'sender') {
-          $url.css('color', 'var(--cyan-100)');
-        }
-      }
-      $sanitized_content = $url;
-    } else {
-      $sanitized_content = __($('<div>').text(content).html());
-    }
+		const n = content.lastIndexOf('/');
+		const file_name = content.substring(n + 1) || '';
+		let $sanitized_content;
 
-    if (type === 'sender' && this.profile.room_type === 'Group') {
-      $message_element.append($name_element);
-    }
-    $message_element.append($sanitized_content);
+		if (content.startsWith('/files/') && file_name !== '') {
+			let $url;
+			if (is_image(file_name)) {
+				$url = $(document.createElement('img'));
+				$url.attr({ src: content })
+					.addClass('img-responsive chat-image')
+					.css({ cursor: 'zoom-in' })
+					.attr('title', __('Click to view full size'));
+				$message_element.css({ padding: '0px', background: 'inherit' });
+				$name_element.css({
+					color: 'var(--text-muted)',
+					'padding-bottom': 'var(--padding-xs)',
+				});
+			} else {
+				$url = $(document.createElement('a'));
+				$url.attr({ href: content, target: '_blank' }).text(__(file_name));
 
-    // Add caption below image/media if present
-    if (caption) {
-      const $caption_element = $(document.createElement('div'))
-        .addClass('message-caption')
-        .css({
-          'padding': 'var(--padding-sm)',
-          'font-size': 'var(--text-sm)',
-          'color': type === 'sender' ? 'var(--white)' : 'var(--text-color)',
-          'background': type === 'sender' ? 'var(--primary-color)' : 'var(--control-bg)',
-          'border-radius': '0 0 13px 13px',
-        })
-        .text(caption);
-      $message_element.append($caption_element);
-    }
+				if (type === 'sender') {
+					$url.css('color', 'var(--cyan-100)');
+				}
+			}
+			$sanitized_content = $url;
+		} else {
+			$sanitized_content = __($('<div>').text(content).html());
+		}
 
-    $recipient_element.append($message_element);
-    $recipient_element.append(`<div class='message-time'>${__(time)}</div>`);
+		if (type === 'sender' && this.profile.room_type === 'Group') {
+			$message_element.append($name_element);
+		}
+		$message_element.append($sanitized_content);
 
-    return $recipient_element;
-  }
+		// Add caption below image/media if present
+		if (caption) {
+			const $caption_element = $(document.createElement('div'))
+				.addClass('message-caption')
+				.css({
+					'padding': 'var(--padding-sm)',
+					'font-size': 'var(--text-sm)',
+					'color': type === 'sender' ? 'var(--white)' : 'var(--text-color)',
+					'background': type === 'sender' ? 'var(--primary-color)' : 'var(--control-bg)',
+					'border-radius': '0 0 13px 13px',
+				})
+				.text(caption);
+			$message_element.append($caption_element);
+		}
 
-  handle_send_message(attachment) {
-    const $type_message = $('.type-message');
-    let content = null;
+		$recipient_element.append($message_element);
 
-    if (attachment) {
-      content = attachment;
-    } else {
-      content = $type_message.val();
-    }
+		// Build time + tick row
+		const tick_html = type === 'recipient' ? this.get_status_tick(status, direction || 'Outgoing') : '';
+		$recipient_element.append(`<div class='message-time'>${__(time)}${tick_html ? ' ' + tick_html : ''}</div>`);
 
-    if (content.length === 0) {
-      return;
-    }
-    this.typing = false;
-    if (this.timeout) {
-      clearTimeout(this.timeout);
-    }
+		return $recipient_element;
+	}
 
-    if (
-      this.profile.is_admin === true &&
-      frappe.Chat.settings.user.enable_message_tone === 1
-    ) {
-      frappe.utils.play_sound('chat-message-send');
-    }
+	handle_send_message(attachment) {
+		const $type_message = $('.type-message');
+		let content = null;
 
-    this.$chat_space_container.append(
-      this.make_message(content, get_time(), 'recipient', this.profile.user)
-    );
-    $type_message.val('');
-    scroll_to_bottom(this.$chat_space_container);
-    send_message(
-      content,
-      this.profile.user,
-      this.profile.room,
-      this.profile.user_email,
-      attachment
-    );
-  }
+		if (attachment) {
+			content = attachment;
+		} else {
+			content = $type_message.val();
+		}
 
-  receive_message(res, time) {
-    let chat_type = 'sender';
-    // Skip if this is our own outgoing message (sender_user_no would be empty or 'Administrator' for outgoing)
-    if (res.sender_user_no === 'Administrator' || res.sender_user_no === this.profile.user) {
-      return;
-    }
+		if (content.length === 0) {
+			return;
+		}
+		this.typing = false;
+		if (this.timeout) {
+			clearTimeout(this.timeout);
+		}
 
-    if (
-      this.profile.is_admin === true &&
-      $('.chat-element').is(':visible') &&
-      frappe.Chat.settings.user.enable_message_tone === 1
-    ) {
-      frappe.utils.play_sound('chat-message-receive');
-    }
+		if (
+			this.profile.is_admin === true &&
+			frappe.Chat.settings.user.enable_message_tone === 1
+		) {
+			frappe.utils.play_sound('chat-message-send');
+		}
 
-    if (this.profile.room_type === 'Guest') {
-      if (this.profile.is_admin === true && res.user !== 'Guest') {
-        chat_type = 'recipient';
-      }
-    }
+		this.$chat_space_container.append(
+			this.make_message(content, get_time(), 'recipient', this.profile.user, null, 'sent', 'Outgoing')
+		);
+		$type_message.val('');
+		scroll_to_bottom(this.$chat_space_container);
+		send_message(
+			content,
+			this.profile.user,
+			this.profile.room,
+			this.profile.user_email,
+			attachment
+		);
+	}
 
-    this.$chat_space_container.append(
-      this.make_message(res.content, time, chat_type, res.user)
-    );
-    scroll_to_bottom(this.$chat_space_container);
-  }
+	receive_message(res, time) {
+		let chat_type = 'sender';
+		// Skip if this is our own outgoing message
+		if (res.sender_user_no === 'Administrator' || res.sender_user_no === this.profile.user) {
+			return;
+		}
 
-  render() {
-    this.$wrapper.html(this.$chat_space);
-    this.setup_events();
+		if (
+			this.profile.is_admin === true &&
+			$('.chat-element').is(':visible') &&
+			frappe.Chat.settings.user.enable_message_tone === 1
+		) {
+			frappe.utils.play_sound('chat-message-receive');
+		}
 
-    scroll_to_bottom(this.$chat_space_container);
-  }
+		if (this.profile.room_type === 'Guest') {
+			if (this.profile.is_admin === true && res.user !== 'Guest') {
+				chat_type = 'recipient';
+			}
+		}
+
+		this.$chat_space_container.append(
+			this.make_message(res.content, time, chat_type, res.user, null, null, 'Incoming')
+		);
+		scroll_to_bottom(this.$chat_space_container);
+	}
+
+	render() {
+		this.$wrapper.html(this.$chat_space);
+		this.setup_events();
+
+		scroll_to_bottom(this.$chat_space_container);
+	}
 }

--- a/whatsapp_chat/public/js/components/chat_utils.js
+++ b/whatsapp_chat/public/js/components/chat_utils.js
@@ -106,6 +106,10 @@ async function mark_message_read(room) {
         room: room,
       },
     });
+    // Every caller of this changes the unread state on the server, and two
+    // of the three never touched the badge. Reconciling here covers all of
+    // them at once.
+    refresh_notification_count();
   } catch (error) {
     //pass
   }
@@ -170,19 +174,59 @@ function get_avatar_html(room_type, user_email, room_name) {
   return avatar_html;
 }
 
-function set_notification_count(type) {
-  const current_count = frappe.Chat.settings.unread_count;
-  if (type === 'increment') {
-    $('#chat-notification-count').text(current_count + 1);
-    frappe.Chat.settings.unread_count += 1;
-  } else {
-    if (current_count - 1 === 0) {
-      $('#chat-notification-count').text('');
-    } else {
-      $('#chat-notification-count').text(current_count - 1);
+/**
+ * Paint the badge. Never below zero, blank at zero.
+ *
+ * The old code blanked the badge only when `current - 1 === 0`, so a
+ * decrement at zero rendered a literal "-1" in the navbar.
+ */
+function render_notification_count(count) {
+  const value = Math.max(0, Number(count) || 0);
+  frappe.Chat.settings.unread_count = value;
+  $('#chat-notification-count').text(value > 0 ? value : '');
+  return value;
+}
+
+let unread_refresh_timer = null;
+
+/**
+ * Ask the server for the true unread-chat count and repaint.
+ *
+ * The badge was a running +/-1 tally seeded once at page load, so every
+ * path that changes read state had to adjust it by exactly one — and
+ * several never did (chat_list's mark_message_read when a message lands on
+ * an open chat, and both chat_space calls). It drifted and stayed wrong
+ * until a reload. The server is now the authority; the tally survives only
+ * as instant feedback.
+ *
+ * Debounced, so a burst of arriving messages costs one request, not one
+ * each.
+ */
+function refresh_notification_count() {
+  clearTimeout(unread_refresh_timer);
+  unread_refresh_timer = setTimeout(async () => {
+    try {
+      const res = await frappe.call({
+        method: 'whatsapp_chat.api.contacts.unread_count',
+      });
+      render_notification_count(res.message);
+    } catch (error) {
+      // Keep the optimistic value rather than blanking a badge that may
+      // well be right; the next event reconciles it.
     }
-    frappe.Chat.settings.unread_count -= 1;
-  }
+  }, 400);
+}
+
+/**
+ * Optimistic +/-1 for immediate feedback, then reconciled against the
+ * server. Callers stay unchanged.
+ */
+function set_notification_count(type) {
+  const current_count = Number(frappe.Chat.settings.unread_count) || 0;
+  render_notification_count(
+    type === 'increment' ? current_count + 1 : current_count - 1
+  );
+  refresh_notification_count();
 }
 
 export {
@@ -202,4 +246,6 @@ export {
   set_user_settings,
   get_avatar_html,
   set_notification_count,
+  refresh_notification_count,
+  render_notification_count,
 };

--- a/whatsapp_chat/whatsapp_chat/doctype/whatsapp_contact/whatsapp_contact.json
+++ b/whatsapp_chat/whatsapp_chat/doctype/whatsapp_contact/whatsapp_contact.json
@@ -7,6 +7,7 @@
  "field_order": [
   "contact_name",
   "mobile_no",
+  "contact",
   "is_read",
   "last_message",
   "email"
@@ -22,6 +23,13 @@
    "fieldtype": "Data",
    "label": "Mobile No",
    "unique": 1
+  },
+  {
+   "description": "Matched automatically on the last 10 digits of the mobile number. Set it by hand to correct a wrong match — an existing link is never overwritten. Clear it to force a fresh match.",
+   "fieldname": "contact",
+   "fieldtype": "Link",
+   "label": "ERPNext Contact",
+   "options": "Contact"
   },
   {
    "default": "0",


### PR DESCRIPTION
## Problem

The WhatsApp chat list displays raw phone numbers (e.g. `919349125225`) as the contact name, making it impossible for sales team members to identify who they are talking to without memorising numbers.

## Solution

`WhatsApp Profiles` (from `frappe_whatsapp`) stores a human-readable `title` field that is automatically set from the sender's WhatsApp profile name on each incoming message (e.g. `"Ravi - 917842272227"`).

This PR enriches the `contacts.get` API response with a `display_name` field sourced from `WhatsApp Profiles`, and uses it as the chat room title in the chat list.

### Changes

**`whatsapp_chat/api/contacts.py`**
- After fetching `WhatsApp Contact` records, look up the matching `WhatsApp Profiles` record by `mobile_no` and attach its `title` as `display_name`
- - Falls back to `contact_name` (the phone number) if no profile title exists — fully backward compatible
**`whatsapp_chat/public/js/components/chat_list.js`**
- `room_name` now uses `element.display_name || element.contact_name` (one-line change)
## Result

The chat list shows names like `"Ravi - 917842272227"` or `"Indiocean Group - 917021472886"` instead of raw phone numbers, making it easy for the sales team to identify customers at a glance.