### PR TITLE
fix: restore Show Chats navbar icon on v16 desk

### DIFF
--- a/whatsapp_chat/public/js/whatsapp_chat.bundle.js
+++ b/whatsapp_chat/public/js/whatsapp_chat.bundle.js
@@ -51,9 +51,35 @@ frappe.Chat = class {
     `;
 
     if (this.is_desk === true) {
-      $('header.navbar > .container > .navbar-collapse > ul').prepend(
-        navbar_icon_html
+      const $legacy_navbar = $(
+        'header.navbar > .container > .navbar-collapse > ul'
       );
+      const $v16_navbar = $('header.navbar > div.flex');
+
+      if ($legacy_navbar.length) {
+        // v14 / v15 desk: navbar items are <li> elements inside a <ul>.
+        $legacy_navbar.prepend(navbar_icon_html);
+      } else if ($v16_navbar.length) {
+        // v16 desk: the .container / .navbar-collapse / <ul> chain is gone.
+        // Right side icons are buttons in a flex container, so the <li>
+        // markup above does not apply here.
+        const $chat_icon = $(`
+          <button class='btn-reset nav-link text-muted chat-navbar-icon'
+            title="Show Chats" aria-label="Show Chats">
+            ${frappe.utils.icon('small-message', 'md')}
+            <span class="badge" id="chat-notification-count"></span>
+          </button>
+        `);
+        const $notifications = $v16_navbar.children('.desktop-notifications');
+        if ($notifications.length) {
+          $chat_icon.insertBefore($notifications);
+        } else {
+          $v16_navbar.prepend($chat_icon);
+        }
+      } else {
+        // Unknown desk layout: fall back to the floating chat bubble.
+        $('.chat-bubble').removeClass('d-none');
+      }
     }
     this.setup_events();
   }


### PR DESCRIPTION
### Problem

On a v16 desk the app has no visible entry point at all. The `Show Chats` navbar icon never appears, and the floating bubble stays hidden, so the chat UI cannot be opened.

Two things combine:

1. `chat_bubble.js` hides the bubble on desk (`is_desk === true` adds `d-none`), on the assumption the navbar icon will be there instead.
2. `whatsapp_chat.bundle.js` injects that icon into `header.navbar > .container > .navbar-collapse > ul`. On v16 that selector matches nothing, and `.prepend()` on an empty jQuery set is a silent no-op.

Net result: bubble hidden, icon never inserted, no way in. Nothing throws, so there is no error to trace.

### What changed in v16

`header.navbar` still exists — the `.container > .navbar-collapse > ul` chain beneath it is what is gone. Observed on Frappe v16.31.0:

```
header.desktop-navbar.navbar.navbar-expand.navbar-container
├── div.navbar-home
├── div.desktop-search-wrapper.input-group.search-bar
└── div.flex
    ├── button.btn-reset.nav-link.text-muted.desktop-cloud-settings
    ├── div.desktop-notifications
    └── div.desktop-avatar
```

The right-hand icons are now buttons in a flex container rather than `<li>` items in a `<ul>`, so the existing `navbar_icon_html` would not be correct markup for v16 even if a container were found.

### Fix

Detect which layout is present:

- **v14 / v15** — unchanged; `navbar_icon_html` is prepended to the `<ul>`.
- **v16** — insert a `<button>` matching the sibling markup, placed before `.desktop-notifications`.
- **Neither** — un-hide the floating bubble, so there is always some entry point.

`.chat-navbar-icon` is preserved, so the existing click handler in `setup_events()` and the `$('.chat-navbar-icon').click()` call in `chat_list.js` keep working unchanged.

### Testing

`frappe.utils.icon('small-message', 'md')` confirmed present on v16.31.0.

The v16 branch was checked by injecting it into a live v16 desk: the button renders at the expected size and position, inline with the other navbar icons and immediately left of notifications.